### PR TITLE
Fix annoying React linting message

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -8,6 +8,11 @@ module.exports = {
 	plugins: [
 		'jquery',
 	],
+	settings: {
+		react: {
+			version: '999.999.999',
+		},
+	},
 	rules: {
 		'jsx-a11y/href-no-hash': 0,
 		'jquery/no-ajax': 2,


### PR DESCRIPTION
Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.

See: \node_modules\eslint-plugin-react\lib\util\version.js for where I came up with 999.999.999