### PR TITLE
feat!: create custom ESLint config, upgrade Stylelint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,32 +4,29 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '14', '15', '16' ]
+
     steps:
       - uses: actions/checkout@v3
-
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
+          node-version: ${{ matrix.node }}
+      - name: Cache Node modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+      - if: ${{ steps.cache.outputs.cache-hit == 'false' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
-
-      - name: Build & Test
-        run: npm run test
+        run: npm install
         env:
-          CI: true
+          ci: true
+      - name: Build & Test
+        run: npm test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - master # TODO: Remove this
 name: release-please
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           release-type: node
           package-name: pressbooks-build-tools
+          include-v-in-tag: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - main
+      - master # TODO: Remove this
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: pressbooks-build-tools

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "${1}"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no lint-staged

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This repo includes a boilerplate `webpack.mix.js` configuration used to test tha
 
 ```
 npm install
-npm run test
+npm test
 ```
 
 Expected: No errors. Everything is fine.

--- a/assets/src/scripts/test.js
+++ b/assets/src/scripts/test.js
@@ -12,4 +12,5 @@ jQuery( function ( $ ) {
 
 	fibonacci( 4 );
 
+	$( 'body' ).removeClass( 'no-js' );
 } );

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: [ '@commitlint/config-conventional' ] };

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,16 +1,134 @@
-
 module.exports = {
-	extends: '@humanmade/eslint-config',
+	root: true,
+	env: {
+		'browser': true,
+		'es6': true,
+		'node': true,
+	},
+	extends: [
+		'eslint:recommended',
+		'plugin:import/errors',
+		'plugin:jsdoc/recommended',
+	],
 	globals: {
 		jQuery: true,
 		wp: true,
 	},
-	settings: {
-		react: {
-			version: '999.999.999',
-		},
+	parserOptions: {
+		ecmaVersion: 2018,
+		sourceType: 'module',
 	},
 	rules: {
-		'jsx-a11y/href-no-hash': 0,
+		'array-bracket-spacing': [ 'error', 'always' ],
+		'arrow-parens': [ 'error', 'as-needed' ],
+		'arrow-spacing': [ 'error', {
+			before: true,
+			after: true,
+		} ],
+		'block-spacing': [ 'error' ],
+		'brace-style': [ 'error', '1tbs' ],
+		'comma-dangle': [ 'error', {
+			arrays: 'always-multiline',
+			objects: 'always-multiline',
+			imports: 'always-multiline',
+			exports: 'always-multiline',
+			functions: 'never',
+		} ],
+		'comma-spacing': [ 'error', {
+			before: false,
+			after: true,
+		} ],
+		'eol-last': [ 'error', 'unix' ],
+		eqeqeq: [ 'error' ],
+		'func-call-spacing': [ 'error' ],
+		'import/no-unresolved': [ 'off' ],
+		'import/order': [ 'error', {
+			alphabetize: {
+				order: 'asc',
+				caseInsensitive: true,
+			},
+			groups: [ 'builtin', 'external', 'parent', 'sibling', 'index' ],
+			'newlines-between': 'always',
+			pathGroups: [
+				{
+					pattern: '@wordpress/**',
+					group: 'external',
+					position: 'after',
+				},
+			],
+			pathGroupsExcludedImportTypes: [ 'builtin' ],
+		} ],
+		indent: [ 'error', 'tab', {
+			SwitchCase: 1,
+		} ],
+		'key-spacing': [ 'error', {
+			beforeColon: false,
+			afterColon: true,
+		} ],
+		'keyword-spacing': [ 'error', {
+			after: true,
+			before: true,
+		} ],
+		'linebreak-style': [ 'error', 'unix' ],
+		'no-console': [ 'warn' ],
+		'no-mixed-spaces-and-tabs': [ 'error', 'smart-tabs' ],
+		'no-multiple-empty-lines': [ 'error', {
+			max: 1,
+		} ],
+		'no-trailing-spaces': [ 'error' ],
+		'no-var': [ 'warn' ],
+		'object-curly-newline': [ 'error', {
+			ObjectExpression: {
+				consistent: true,
+				minProperties: 2,
+				multiline: true,
+			},
+			ObjectPattern: {
+				consistent: true,
+				multiline: true,
+			},
+			ImportDeclaration: {
+				consistent: true,
+				multiline: true,
+			},
+			ExportDeclaration: {
+				consistent: true,
+				minProperties: 2,
+				multiline: true,
+			},
+		} ],
+		'object-curly-spacing': [ 'error', 'always' ],
+		'object-property-newline': [ 'error' ],
+		quotes: [ 'error', 'single' ],
+		semi: [ 'error', 'always' ],
+		'semi-spacing': [ 'error', {
+			before: false,
+			after: true,
+		} ],
+		'space-before-function-paren': [ 'error', {
+			anonymous: 'always',
+			asyncArrow: 'always',
+			named: 'never',
+		} ],
+		'space-in-parens': [ 'warn', 'always', {
+			exceptions: [ 'empty' ],
+		} ],
+		'space-unary-ops': [ 'error', {
+			words: true,
+			nonwords: false,
+			overrides: {
+				'!': true,
+			},
+		} ],
+		'template-curly-spacing': [ 'error', 'always' ],
+		yoda: [ 'error', 'never' ],
+		'jsdoc/require-jsdoc': [ 'error', {
+			require: {
+				FunctionDeclaration: true,
+				ClassDeclaration: true,
+				ArrowFunctionExpression: true,
+				FunctionExpression: true,
+			},
+		} ],
 	},
 };

--- a/config/stylelint.js
+++ b/config/stylelint.js
@@ -1,9 +1,10 @@
 module.exports = {
 	extends: [
-		'stylelint-config-recommended-scss',
-		'./node_modules/prettier-stylelint/config.js',
+		'stylelint-config-standard-scss',
+		'stylelint-config-prettier',
 	],
 	rules: {
+		'scss/comment-no-empty': null,
 		'scss/at-rule-no-unknown': [
 			true,
 			{
@@ -35,9 +36,11 @@ module.exports = {
 				],
 			},
 		],
+		'selector-class-pattern': null,
 		'selector-pseudo-element-no-unknown': [
 			true,
 			{ ignorePseudoElements: [ 'footnote-call' ] },
 		],
+		'no-descending-specificity': null,
 	},
 };

--- a/package.json
+++ b/package.json
@@ -11,15 +11,19 @@
     "url": "git+https://github.com/pressbooks/pressbooks-build-tools.git"
   },
   "license": "GPL-3.0-or-later",
-  "author": "Pressbooks <code@pressbooks.com> (Book Oven Inc.)",
-  "main": "index.js",
+  "author": {
+    "name": "Pressbooks (Book Oven Inc.)",
+    "email": "code@pressbooks.com",
+    "url": "https://pressbooks.org/"
+  },
   "scripts": {
     "build": "mix --production",
     "fix": "eslint --fix **/*.js",
     "lint": "run-s lint:*",
     "lint:scripts": "eslint config/*.js assets/src/scripts/*.js",
     "lint:styles": "stylelint **/*.scss",
-    "test": "run-s lint:* build"
+    "test": "run-s lint:* build",
+    "prepare": "husky install"
   },
   "eslintConfig": {
     "extends": "./config/eslint.js"
@@ -27,32 +31,39 @@
   "stylelint": {
     "extends": "./config/stylelint.js"
   },
+  "engines": {
+    "node": ">= 14"
+  },
   "dependencies": {
-    "@humanmade/eslint-config": "^1.1.3",
     "babel-eslint": "^10.1.0",
     "browser-sync": "^2.27.1",
     "browser-sync-webpack-plugin": "^2.3.0",
     "cross-env": "^7.0.3",
-    "eslint": "^7.29.0",
-    "eslint-config-react-app": "^6.0.0",
-    "eslint-plugin-flowtype": "^5.7.2",
-    "eslint-plugin-import": "^2.23.4",
-    "eslint-plugin-jsdoc": "^35.4.0",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.24.0",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-sort-destructure-keys": "^1.3.5",
+    "eslint": "^8.22.0",
+    "eslint-plugin-flowtype": "^8.0.3",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsdoc": "^39.3.6",
+    "eslint-plugin-sort-destructure-keys": "^1.4.0",
     "laravel-mix": "^6.0.25",
     "postcss": "^8.3.5",
     "prettier-stylelint": "^0.4.2",
     "resolve-url-loader": "^4.0.0",
     "sass": "^1.35.1",
     "sass-loader": "^12.1.0",
-    "stylelint": "^13.13.1",
-    "stylelint-config-recommended-scss": "^4.2.0",
-    "stylelint-scss": "^3.19.0"
+    "stylelint": "^14.10.0",
+    "stylelint-config-prettier": "^9.0.3",
+    "stylelint-config-recommended": "^9.0.0",
+    "stylelint-config-standard-scss": "^5.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^17.0.3",
+    "@commitlint/config-conventional": "^17.0.3",
+    "husky": "^8.0.1",
+    "lint-staged": "^13.0.3",
     "npm-run-all": "^4.1.5"
+  },
+  "lint-staged": {
+    "*.js": "eslint --fix",
+    "*.scss": "stylelint --fix"
   }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,7 +17,7 @@ let mix = require( 'laravel-mix' );
  */
 
 const assets = 'assets';
-const dist = `${assets}/dist`;
+const dist = `${ assets }/dist`;
 const templates = 'templates';
 
 // BrowserSync
@@ -27,9 +27,9 @@ mix.browserSync( {
 	port: 3100,
 	files: [
 		'*.php',
-		`${templates}/**/*.php`,
-		`${dist}/styles/*.css`,
-		`${dist}/scripts/*.js`,
+		`${ templates }/**/*.php`,
+		`${ dist }/styles/*.css`,
+		`${ dist }/scripts/*.js`,
 	],
 } );
 


### PR DESCRIPTION
This PR:

1. Fixes Pressbooks Build Tools for Node 16 by removing dependencies which break `npm install`.
2. Creates a custom ESLint configuration for Pressbooks based on `eslint-config-humanmade`, minus the React linting which isn't used.
3. Upgrades Stylelint to latest, disabling significant breaking rules (other issues may arise but these can be easily addressed).
4. Adds git hooks to run linters and [commitlint](https://commitlint.js.org).
5. Adds automatic versioning and CHANGELOG updating using [release-please](https://github.com/google-github-actions/release-please-action).

### Related Issues

- Resolves #283
- Resolves #276