### PR TITLE
fix: ssl cert for local developent tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,40 @@ You can create granular scripts for different parts of your project:
 }
 ```
 
+### HTTPS & SSL Certificates
+
+The dev server runs over HTTPS by default. To get **trusted certificates** (no browser warnings), the build tools use [mkcert](https://github.com/FiloSottile/mkcert) to generate locally-trusted SSL certificates automatically.
+
+#### One-time setup
+
+```bash
+brew install mkcert   # macOS (or: apt install mkcert on Linux)
+mkcert -install
+```
+
+That's it. The next time you run `pressbooks-build-tools dev`, trusted certificates for `localhost` will be generated and cached automatically. You only need to run the commands above once per machine.
+
+#### How it works
+
+- If **mkcert is installed**, the build tools generate trusted certificates for `localhost`, `127.0.0.1`, and `::1`, cached in `~/.local/share/pressbooks-build-tools/certs/` (regenerated every 30 days).
+- If **mkcert is not installed**, the dev server falls back to a self-signed certificate. This works fine for local development (`https://pressbooks.test`) but will cause `ERR_CERT_AUTHORITY_INVALID` errors if you use tunneling services.
+- If setup is missing, a warning with instructions is printed when the dev server starts.
+
+#### Using tunneling services (ngrok, Cloudflare Tunnel, etc.)
+
+Trusted certificates via mkcert are **required** when accessing your local dev environment through a tunnel. Without them, browsers will block cross-origin requests from the tunnel origin to `localhost:3100`.
+
+The dev server also includes support for Chrome's [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/) spec, which requires servers to explicitly allow requests from public origins to local network addresses.
+
+To disable HTTPS entirely, pass `https: false` in your config:
+
+```javascript
+export default createWpViteConfig({
+  https: false,
+  // ...
+});
+```
+
 #### Configuration Options
 
 The `createViteConfig` function accepts these options:
@@ -153,6 +187,7 @@ The `createViteConfig` function accepts these options:
 - `proxy` - Development server proxy configuration
 - `copyTargets` - Array of files/directories to copy during build (see below)
 - `plugins` - Additional Vite plugins to include
+- `https` - Whether to enable HTTPS (default: `true`)
 - `config` - Additional Vite configuration to merge
 
 #### File Copying with copyTargets

--- a/config/ssl.js
+++ b/config/ssl.js
@@ -1,0 +1,190 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const CERT_DIR = path.join( os.homedir(), '.local', 'share', 'pressbooks-build-tools', 'certs' );
+const KEY_FILE = path.join( CERT_DIR, 'localhost-key.pem' );
+const CERT_FILE = path.join( CERT_DIR, 'localhost.pem' );
+
+/**
+ * Checks if mkcert is installed and available in the system PATH.
+ * @returns {boolean} True if mkcert is available
+ */
+function hasMkcert() {
+	try {
+		execSync( 'mkcert --version', { stdio: 'ignore' } );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Checks if the mkcert root CA has been installed in the system trust store.
+ * @returns {boolean} True if the CA root certificate exists
+ */
+function isCaInstalled() {
+	try {
+		const caRoot = execSync( 'mkcert -CAROOT', { encoding: 'utf-8' } ).trim();
+		return fs.existsSync( path.join( caRoot, 'rootCA.pem' ) );
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Checks if certificate files already exist and are not expired.
+ * Certificates are considered valid for 30 days.
+ * @returns {boolean} True if valid certificates exist
+ */
+function certsExist() {
+	if ( ! fs.existsSync( KEY_FILE ) || ! fs.existsSync( CERT_FILE ) ) {
+		return false;
+	}
+	// Check if cert is older than 30 days
+	const stats = fs.statSync( CERT_FILE );
+	const ageMs = Date.now() - stats.mtimeMs;
+	const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+	return ageMs < thirtyDays;
+}
+
+/**
+ * Generates trusted SSL certificates for localhost using mkcert.
+ * Creates certificates in ~/.local/share/pressbooks-build-tools/certs/.
+ * Requires mkcert to be installed and its CA root to be set up.
+ * @returns {boolean} True if certificates were successfully generated
+ */
+function generateCerts() {
+	try {
+		fs.mkdirSync( CERT_DIR, { recursive: true } );
+		execSync(
+			`mkcert -key-file "${ KEY_FILE }" -cert-file "${ CERT_FILE }" localhost 127.0.0.1 ::1`,
+			{ stdio: 'pipe' }
+		);
+		return true;
+	} catch ( err ) {
+		console.warn( '[pressbooks-build-tools] Failed to generate mkcert certificates:', err.message );
+		return false;
+	}
+}
+
+/**
+ * Prints a boxed warning message to the console for visibility.
+ * @param {string[]} lines - Array of message lines to display
+ */
+function printWarning( lines ) {
+	const maxLen = Math.max( ...lines.map( l => l.length ) );
+	const border = '─'.repeat( maxLen + 2 );
+	console.warn( '' );
+	console.warn( `  ┌${ border }┐` );
+	for ( const line of lines ) {
+		console.warn( `  │ ${ line.padEnd( maxLen ) } │` );
+	}
+	console.warn( `  └${ border }┘` );
+	console.warn( '' );
+}
+
+/**
+ * Returns the HTTPS configuration for Vite's server.https option.
+ * Attempts to use mkcert for locally-trusted certificates. If mkcert is not
+ * available or its CA is not installed, falls back to true (Vite's default
+ * self-signed cert) and prints setup instructions.
+ *
+ * Using mkcert-generated certificates is important for development with tunneling
+ * services (e.g., ngrok) because browsers reject self-signed certificates for
+ * cross-origin subresource requests from public origins.
+ * @returns {object|boolean} An object with key/cert buffers for mkcert certs,
+ *                           or true to use Vite's default self-signed cert
+ */
+export function getHttpsConfig() {
+	if ( ! hasMkcert() ) {
+		printWarning( [
+			'mkcert not found — using a self-signed certificate.',
+			'',
+			'Browsers will show certificate warnings, and tunneling',
+			'services (ngrok, Cloudflare Tunnel, etc.) will not work.',
+			'',
+			'To fix this, run once:',
+			'',
+			'  brew install mkcert   # or: apt install mkcert',
+			'  mkcert -install',
+			'',
+			'Then restart the dev server.',
+		] );
+		return true;
+	}
+
+	if ( ! isCaInstalled() ) {
+		printWarning( [
+			'mkcert is installed but its CA is not trusted yet.',
+			'',
+			'To fix this, run once:',
+			'',
+			'  mkcert -install',
+			'',
+			'Then restart the dev server.',
+		] );
+		return true;
+	}
+
+	if ( ! certsExist() ) {
+		console.log( '[pressbooks-build-tools] Generating trusted SSL certificates with mkcert...' );
+		if ( ! generateCerts() ) {
+			printWarning( [
+				'Failed to generate certificates with mkcert.',
+				'Falling back to a self-signed certificate.',
+				'',
+				'Try running manually:',
+				`  mkcert -key-file "${ KEY_FILE }" -cert-file "${ CERT_FILE }" localhost 127.0.0.1 ::1`,
+			] );
+			return true;
+		}
+		console.log( '[pressbooks-build-tools] Trusted SSL certificates ready.' );
+	}
+
+	return {
+		key: fs.readFileSync( KEY_FILE ),
+		cert: fs.readFileSync( CERT_FILE ),
+	};
+}
+
+/**
+ * Creates a Vite plugin that adds Private Network Access (PNA) headers.
+ * This is required when the dev server (localhost) is accessed from an external
+ * origin such as ngrok or other tunneling services. Chrome's PNA spec requires
+ * the server to respond with Access-Control-Allow-Private-Network: true on
+ * preflight requests from public origins targeting local network resources.
+ * @returns {object} Vite plugin object
+ */
+export function privateNetworkAccessPlugin() {
+	return {
+		name: 'private-network-access',
+		/**
+		 *
+		 * @param server
+		 */
+		configureServer( server ) {
+			server.middlewares.use( ( req, res, next ) => {
+				// Set CORS headers on all responses
+				res.setHeader( 'Access-Control-Allow-Origin', '*' );
+				res.setHeader( 'Access-Control-Allow-Methods', 'GET, OPTIONS' );
+				res.setHeader( 'Access-Control-Allow-Headers', '*' );
+
+				// Handle Private Network Access preflight
+				if ( req.headers[ 'access-control-request-private-network' ] ) {
+					res.setHeader( 'Access-Control-Allow-Private-Network', 'true' );
+				}
+
+				// Respond to preflight requests immediately
+				if ( req.method === 'OPTIONS' ) {
+					res.statusCode = 204;
+					res.end();
+					return;
+				}
+
+				next();
+			} );
+		},
+	};
+}

--- a/config/vite.config.base.js
+++ b/config/vite.config.base.js
@@ -1,10 +1,11 @@
 import path from 'path';
 
-import basicSsl from '@vitejs/plugin-basic-ssl';
 import legacy from '@vitejs/plugin-legacy';
 import { defineConfig } from 'vite';
 import liveReload from 'vite-plugin-live-reload';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+import { getHttpsConfig, privateNetworkAccessPlugin } from './ssl.js';
 
 /**
  * Creates a Vite configuration with Pressbooks-specific defaults
@@ -30,6 +31,7 @@ export function createViteConfig( options = {} ) {
 			'**/*.php',
 			'templates/**/*.php',
 		] ),
+		privateNetworkAccessPlugin(),
 	];
 
 	// Add static copy plugin if copyTargets are provided
@@ -37,11 +39,6 @@ export function createViteConfig( options = {} ) {
 		plugins.push( viteStaticCopy( {
 			targets: options.copyTargets,
 		} ) );
-	}
-
-	// Add basic SSL plugin for HTTPS development
-	if ( useHttps ) {
-		plugins.push( basicSsl() );
 	}
 
 	// Add any additional plugins
@@ -102,8 +99,8 @@ export function createViteConfig( options = {} ) {
 			},
 		},
 		server: {
-			https: useHttps,
-			cors: true,
+			https: useHttps ? getHttpsConfig() : false,
+			cors: false, // Handled by privateNetworkAccessPlugin for PNA support
 			proxy: options.proxy || {
 				// Default proxy for WordPress development
 				'/wp-admin': {

--- a/config/vite.config.wp.js
+++ b/config/vite.config.wp.js
@@ -1,9 +1,10 @@
 import { v4wp } from '@kucrut/vite-for-wp';
-import basicSsl from '@vitejs/plugin-basic-ssl';
 import autoprefixer from 'autoprefixer';
 import { defineConfig } from 'vite';
 import liveReload from 'vite-plugin-live-reload';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+import { getHttpsConfig, privateNetworkAccessPlugin } from './ssl.js';
 
 /**
  * Creates a WordPress-specific Vite configuration using @kucrut/vite-for-wp
@@ -51,12 +52,8 @@ export function createWpViteConfig( options = {} ) {
 		viteStaticCopy( {
 			targets: options.copyTargets || [],
 		} ),
+		privateNetworkAccessPlugin(),
 	];
-
-	// Add basic SSL plugin for HTTPS development
-	if ( useHttps ) {
-		plugins.push( basicSsl() );
-	}
 
 	// Add any additional plugins
 	if ( options.plugins ) {
@@ -71,8 +68,8 @@ export function createWpViteConfig( options = {} ) {
 			},
 		},
 		server: {
-			https: useHttps,
-			cors: true,
+			https: useHttps ? getHttpsConfig() : false,
+			cors: false, // Handled by privateNetworkAccessPlugin for PNA support
 			proxy: options.proxy || {
 				// Default proxy for WordPress development
 				'/wp-admin': {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@kucrut/vite-for-wp": "^0.12.0",
-    "@vitejs/plugin-basic-ssl": "^2.1.4",
     "@vitejs/plugin-legacy": "^7.2.1",
     "autoprefixer": "^10.4.20",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
This pull request introduces a new approach for handling HTTPS and SSL certificates in the development environment, improving developer experience and compatibility with tunneling services. The build tools now use `mkcert` to generate locally-trusted certificates, replacing the previous reliance on self-signed certificates and the `@vitejs/plugin-basic-ssl` plugin. Additional support for Chrome's Private Network Access (PNA) spec is included to enable seamless development with tunnels like ngrok. The documentation has been updated to reflect these changes and provide clear setup instructions.

**SSL & HTTPS Improvements:**

* Added `config/ssl.js` module to automatically generate and manage trusted SSL certificates using `mkcert`, including certificate caching and setup warnings for missing prerequisites. Also provides a Vite plugin for Private Network Access headers.
* Removed `@vitejs/plugin-basic-ssl` from `package.json` and all Vite config files, fully replacing it with the new mkcert-based solution. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58) [[2]](diffhunk://#diff-168c83d259fa3f8ceaaa82346d29395af1b5710a23ae53c84c67f282785f113bL3-R9) [[3]](diffhunk://#diff-8c7ccd9c97f7670c0ca99dc671f675402ca5b3e0f7ce2ba78b5436979165e9d7L2-R8)

**Vite Configuration Updates:**

* Updated `config/vite.config.base.js` and `config/vite.config.wp.js` to use the new `getHttpsConfig()` function for HTTPS setup and add the `privateNetworkAccessPlugin()` for PNA support. Also changed CORS handling to rely on the plugin. [[1]](diffhunk://#diff-168c83d259fa3f8ceaaa82346d29395af1b5710a23ae53c84c67f282785f113bL105-R103) [[2]](diffhunk://#diff-168c83d259fa3f8ceaaa82346d29395af1b5710a23ae53c84c67f282785f113bR34) [[3]](diffhunk://#diff-168c83d259fa3f8ceaaa82346d29395af1b5710a23ae53c84c67f282785f113bL42-L46) [[4]](diffhunk://#diff-8c7ccd9c97f7670c0ca99dc671f675402ca5b3e0f7ce2ba78b5436979165e9d7R55-L60) [[5]](diffhunk://#diff-8c7ccd9c97f7670c0ca99dc671f675402ca5b3e0f7ce2ba78b5436979165e9d7L74-R72)

**Documentation Enhancements:**

* Expanded `README.md` with a new section explaining HTTPS setup, mkcert installation, certificate generation, and how to disable HTTPS if needed. Clarifies requirements for tunneling services and details the new configuration option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R178) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R190)

### How to test locally

To test these changes, point your plugin/theme to use the local build tools:
1. In your project's package.json, update the pressbooks-build-tools dependency:
"pressbooks-build-tools": "file:/path/to/your/pressbooks-build-tools"

2. Install dependencies:
`npm install`

3. If you haven't already, set up mkcert (one-time):

`brew install mkcert`
`mkcert -install`

5. Start the dev server:
`npm run watch`
